### PR TITLE
test: rename tests to remove ticket suffixes and letter prefixes (0082d)

### DIFF
--- a/msd/msd-sim/test/Environment/WorldModelContactIntegrationTest.cpp
+++ b/msd/msd-sim/test/Environment/WorldModelContactIntegrationTest.cpp
@@ -266,15 +266,15 @@ TEST(WorldModelContactIntegrationTest,
     << "Glancing collision should affect linear velocities. "
     << "finalVxA=" << finalVxA << ", finalVxB=" << finalVxB;
 
-  // NOTE: Angular velocity test skipped due to missing friction constraints.
-  // When friction is implemented, uncomment this:
-  //
-  // double finalOmegaA =
-  // world.getObject(idA).getInertialState().getAngularVelocity().norm(); double
-  // finalOmegaB =
-  // world.getObject(idB).getInertialState().getAngularVelocity().norm(); double
-  // maxOmega = std::max(finalOmegaA, finalOmegaB); EXPECT_GT(maxOmega, 0.01) <<
-  // "Glancing collision with friction should produce angular velocity";
+  // Friction is now implemented (Block PGS, Ticket: 0075b).
+  // Glancing collision with friction should produce angular velocity.
+  double finalOmegaA =
+    world.getObject(idA).getInertialState().getAngularVelocity().norm();
+  double finalOmegaB =
+    world.getObject(idB).getInertialState().getAngularVelocity().norm();
+  double maxOmega = std::max(finalOmegaA, finalOmegaB);
+  EXPECT_GT(maxOmega, 0.01)
+    << "Glancing collision with friction should produce angular velocity";
 }
 
 /**

--- a/msd/msd-sim/test/Physics/Collision/ContactManifoldStabilityTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/ContactManifoldStabilityTest.cpp
@@ -50,7 +50,7 @@ double computeSystemEnergy(const WorldModel& world)
 // Validates: Resting contact stability, no drift/jitter/sinking
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ContactManifoldStabilityTest_D1_RestingCube_StableFor1000Frames)
+TEST_F(ReplayEnabledTest, ContactManifoldStabilityTest_RestingCube_StableFor1000Frames)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062d_replay_stability_edge_contact_tests
@@ -165,7 +165,7 @@ TEST_F(ReplayEnabledTest, ContactManifoldStabilityTest_D1_RestingCube_StableFor1
 //   3. Cube remains on the floor (no fly-away or sinking)
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ContactManifoldStabilityTest_D4_MicroJitter_DampsOut)
+TEST_F(ReplayEnabledTest, ContactManifoldStabilityTest_MicroJitter_DampsOut)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062d_replay_stability_edge_contact_tests

--- a/msd/msd-sim/test/Physics/Collision/EPAConvergenceDiagnosticTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/EPAConvergenceDiagnosticTest.cpp
@@ -45,7 +45,7 @@ std::vector<Coordinate> createCubePoints(double size)
 // Phase 1: Reproduce the H6 EPA convergence failure directly
 // ============================================================================
 
-TEST(EPAConvergenceDiagnostic, H6_TwoCubes_ShallowOverlap)
+TEST(EPAConvergenceDiagnostic, TwoCubes_ShallowOverlap)
 {
   // Exact H6 scenario: two 1m cubes with 0.01m overlap along X-axis
   auto cubePointsA = createCubePoints(1.0);
@@ -560,7 +560,7 @@ TEST(EPAConvergenceDiagnostic, ExactSimulationQuaternionReproduction)
 // Phase 4: Directly probe the exact post-frame-1 configuration
 // ============================================================================
 
-TEST(EPAConvergenceDiagnostic, H6_PostPositionCorrection_DirectProbe)
+TEST(EPAConvergenceDiagnostic, PostPositionCorrection_DirectProbe)
 {
   // After frame 1, PositionCorrector shifts objects:
   // A: 0.0 -> -0.0005, B: 0.99 -> 0.9905

--- a/msd/msd-sim/test/Physics/Collision/EnergyAccountingTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/EnergyAccountingTest.cpp
@@ -44,7 +44,7 @@ double computeSystemEnergy(const WorldModel& world)
 // F1: Free-falling sphere — total energy constant (no collision)
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, EnergyAccountingTest_F1_FreeFall_TotalEnergyConstant)
+TEST_F(ReplayEnabledTest, EnergyAccountingTest_FreeFall_TotalEnergyConstant)
 {
   // Ticket: 0039b_linear_collision_test_suite
 
@@ -79,7 +79,7 @@ TEST_F(ReplayEnabledTest, EnergyAccountingTest_F1_FreeFall_TotalEnergyConstant)
 // F2: Elastic bounce (e=1) — post-bounce KE equals pre-bounce KE
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, EnergyAccountingTest_F2_ElasticBounce_KEConserved)
+TEST_F(ReplayEnabledTest, EnergyAccountingTest_ElasticBounce_KEConserved)
 {
   spawnEnvironment("floor_slab", Coordinate{0.0, 0.0, -50.0});
 
@@ -155,7 +155,7 @@ TEST_F(ReplayEnabledTest, EnergyAccountingTest_F2_ElasticBounce_KEConserved)
 // F3: Inelastic bounce (e=0.5) — post-bounce KE = e^2 * pre-bounce KE
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, EnergyAccountingTest_F3_InelasticBounce_KEReducedByESquared)
+TEST_F(ReplayEnabledTest, EnergyAccountingTest_InelasticBounce_KEReducedByESquared)
 {
   spawnEnvironment("floor_slab", Coordinate{0.0, 0.0, -50.0});
 
@@ -220,7 +220,7 @@ TEST_F(ReplayEnabledTest, EnergyAccountingTest_F3_InelasticBounce_KEReducedByESq
 // F5: Multi-bounce monotonic energy decrease (e=0.8)
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, EnergyAccountingTest_F5_MultiBounce_EnergyDecreases)
+TEST_F(ReplayEnabledTest, EnergyAccountingTest_MultiBounce_EnergyDecreases)
 {
   spawnEnvironment("floor_slab", Coordinate{0.0, 0.0, -50.0});
 

--- a/msd/msd-sim/test/Physics/Collision/LinearCollisionTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/LinearCollisionTest.cpp
@@ -17,10 +17,10 @@
 using namespace msd_sim;
 
 // ============================================================================
-// A1: Sphere drops vertically onto horizontal plane (settling)
+// Sphere drops vertically onto horizontal plane (settling)
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A1_SphereDrop_SettlesToRest)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_SphereDrop_SettlesToRest)
 {
   // NOTE: No friction parameter currently exposed. Tests proceed without
   // setting mu=0; contact-normal-only constraints provide equivalent behavior.
@@ -52,10 +52,10 @@ TEST_F(ReplayEnabledTest, LinearCollisionTest_A1_SphereDrop_SettlesToRest)
 }
 
 // ============================================================================
-// A2: Perfectly inelastic (e=0) sphere drops vertically
+// Perfectly inelastic (e=0) sphere drops vertically
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A2_PerfectlyInelastic_QuickStop)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_PerfectlyInelastic_QuickStop)
 {
   spawnEnvironment("floor_slab", Coordinate{0.0, 0.0, -50.0});
 
@@ -81,10 +81,10 @@ TEST_F(ReplayEnabledTest, LinearCollisionTest_A2_PerfectlyInelastic_QuickStop)
 }
 
 // ============================================================================
-// A3: Perfectly elastic (e=1) sphere — perpetual bouncing
+// Perfectly elastic (e=1) sphere — perpetual bouncing
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A3_PerfectlyElastic_EnergyConserved)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_PerfectlyElastic_EnergyConserved)
 {
   spawnEnvironment("floor_slab", Coordinate{0.0, 0.0, -50.0});
 
@@ -114,10 +114,10 @@ TEST_F(ReplayEnabledTest, LinearCollisionTest_A3_PerfectlyElastic_EnergyConserve
 }
 
 // ============================================================================
-// A4: Two spheres, equal mass, head-on elastic — velocity swap
+// Two spheres, equal mass, head-on elastic — velocity swap
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A4_EqualMassElastic_VelocitySwap)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_EqualMassElastic_VelocitySwap)
 {
   // Remove gravity for clean 1D collision
   disableGravity();
@@ -211,10 +211,10 @@ TEST_F(ReplayEnabledTest, LinearCollisionTest_A4_EqualMassElastic_VelocitySwap)
 }
 
 // ============================================================================
-// A5: Two spheres, unequal mass (10:1), elastic
+// Two spheres, unequal mass (10:1), elastic
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A5_UnequalMassElastic_ClassicalFormulas)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_UnequalMassElastic_ClassicalFormulas)
 {
   // Remove gravity for clean 1D collision
   disableGravity();
@@ -281,10 +281,10 @@ TEST_F(ReplayEnabledTest, LinearCollisionTest_A5_UnequalMassElastic_ClassicalFor
 }
 
 // ============================================================================
-// A6: Glancing collision at offset — impulse along contact normal
+// Glancing collision at offset — impulse along contact normal
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, LinearCollisionTest_A6_GlancingCollision_MomentumAndEnergyConserved)
+TEST_F(ReplayEnabledTest, LinearCollisionTest_GlancingCollision_MomentumAndEnergyConserved)
 {
   // Remove gravity for clean collision
   disableGravity();

--- a/msd/msd-sim/test/Physics/Collision/ParameterIsolationTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/ParameterIsolationTest.cpp
@@ -99,7 +99,7 @@ EnergyTracker::SystemEnergy computeSystemEnergyNoGravity(
 // Baumgarte term (ERP/dt * penetration) is independent of restitution.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H1_DisableRestitution_RestingCube)
+TEST_F(ReplayEnabledTest, ParameterIsolation_DisableRestitution_RestingCube)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -203,7 +203,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H1_DisableRestitution_RestingCube)
 // as the energy source.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H2_MinimalPenetration_NoEnergyGrowth)
+TEST_F(ReplayEnabledTest, ParameterIsolation_MinimalPenetration_NoEnergyGrowth)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -297,7 +297,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H2_MinimalPenetration_NoEnergyGrowt
 // conserved regardless of timestep size.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H3_TimestepSensitivity_ERPAmplification)
+TEST_F(ReplayEnabledTest, ParameterIsolation_TimestepSensitivity_ERPAmplification)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -374,7 +374,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H3_TimestepSensitivity_ERPAmplifica
 // NOTE: This is a single-step geometric check - kept as TEST() not TEST_F()
 // ============================================================================
 
-TEST(ParameterIsolation, H4_SingleContactPoint_TorqueDiagnostic)
+TEST(ParameterIsolation, SingleContactPoint_TorqueDiagnostic)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests (NOT converted - single-step)
@@ -480,7 +480,7 @@ TEST(ParameterIsolation, H4_SingleContactPoint_TorqueDiagnostic)
 // rotation, position drift, or energy growth over 100 frames.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H5_ContactPointCount_EvolutionDiagnostic)
+TEST_F(ReplayEnabledTest, ParameterIsolation_ContactPointCount_EvolutionDiagnostic)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -539,7 +539,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H5_ContactPointCount_EvolutionDiagn
 // correction generates torque.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H6_ZeroGravity_RestingContact_Stable)
+TEST_F(ReplayEnabledTest, ParameterIsolation_ZeroGravity_RestingContact_Stable)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -620,7 +620,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H6_ZeroGravity_RestingContact_Stabl
 // should show dramatically more energy growth.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H7_GravityComparison_BaumgarteAmplification)
+TEST_F(ReplayEnabledTest, ParameterIsolation_GravityComparison_BaumgarteAmplification)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -714,7 +714,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H7_GravityComparison_BaumgarteAmpli
 // more tilt), this confirms the single-contact feedback hypothesis.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H8_TiltedCube_FeedbackLoop)
+TEST_F(ReplayEnabledTest, ParameterIsolation_TiltedCube_FeedbackLoop)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests
@@ -825,7 +825,7 @@ TEST_F(ReplayEnabledTest, ParameterIsolation_H8_TiltedCube_FeedbackLoop)
 // NOTE: This is a purely analytical calculation - kept as TEST() not TEST_F()
 // ============================================================================
 
-TEST(ParameterIsolation, H9_BaumgarteEnergyInjectionAnalysis)
+TEST(ParameterIsolation, BaumgarteEnergyInjectionAnalysis)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests (NOT converted - analytical)
@@ -912,7 +912,7 @@ TEST(ParameterIsolation, H9_BaumgarteEnergyInjectionAnalysis)
 // has reasonable behavior (doesn't fall through floor or explode).
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, ParameterIsolation_H10_IntegrationOrder_ConsistencyCheck)
+TEST_F(ReplayEnabledTest, ParameterIsolation_IntegrationOrder_ConsistencyCheck)
 {
   // Ticket: 0039d_parameter_isolation_root_cause
   // Ticket: 0062e_replay_diagnostic_parameter_tests

--- a/msd/msd-sim/test/Physics/Collision/RotationDampingTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/RotationDampingTest.cpp
@@ -56,7 +56,7 @@ double computeSystemEnergy(const WorldModel& world)
 // Validates: Rotational restitution -- rocking amplitude decreases
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, RotationDampingTest_C2_RockingCube_AmplitudeDecreases)
+TEST_F(ReplayEnabledTest, RotationDampingTest_RockingCube_AmplitudeDecreases)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -163,7 +163,7 @@ TEST_F(ReplayEnabledTest, RotationDampingTest_C2_RockingCube_AmplitudeDecreases)
 // Validates: Multi-contact stability
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, RotationDampingTest_C3_TiltedCubeSettles_ToFlatFace)
+TEST_F(ReplayEnabledTest, RotationDampingTest_TiltedCubeSettles_ToFlatFace)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests

--- a/msd/msd-sim/test/Physics/Collision/RotationalCollisionTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/RotationalCollisionTest.cpp
@@ -53,7 +53,7 @@ double computeSystemEnergy(const WorldModel& world)
 // Validates: Lever arm coupling -- rotation should initiate from off-center impact
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, RotationalCollisionTest_B1_CubeCornerImpact_RotationInitiated)
+TEST_F(ReplayEnabledTest, RotationalCollisionTest_CubeCornerImpact_RotationInitiated)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -150,7 +150,7 @@ TEST_F(ReplayEnabledTest, RotationalCollisionTest_B1_CubeCornerImpact_RotationIn
 // of the edge hits first, generating net torque.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, RotationalCollisionTest_B2_CubeEdgeImpact_PredictableRotationAxis)
+TEST_F(ReplayEnabledTest, RotationalCollisionTest_CubeEdgeImpact_PredictableRotationAxis)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -246,7 +246,7 @@ TEST_F(ReplayEnabledTest, RotationalCollisionTest_B2_CubeEdgeImpact_PredictableR
 // term, no spurious torque → sphere does not rotate ✅
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, RotationalCollisionTest_B3_SphereDrop_NoRotation)
+TEST_F(ReplayEnabledTest, RotationalCollisionTest_SphereDrop_NoRotation)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -302,7 +302,7 @@ TEST_F(ReplayEnabledTest, RotationalCollisionTest_B3_SphereDrop_NoRotation)
 // a "rod" asset (2m x 0.2m x 0.2m).
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, DISABLED_RotationalCollisionTest_B4_RodFallsFlat_NoRotation)
+TEST_F(ReplayEnabledTest, DISABLED_RotationalCollisionTest_RodFallsFlat_NoRotation)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -359,7 +359,7 @@ TEST_F(ReplayEnabledTest, DISABLED_RotationalCollisionTest_B4_RodFallsFlat_NoRot
 // geometric center), the L-shape should rotate upon flat-face impact.
 // ============================================================================
 
-TEST_F(ReplayEnabledTest, DISABLED_RotationalCollisionTest_B5_LShapeDrop_RotationFromAsymmetricCOM)
+TEST_F(ReplayEnabledTest, DISABLED_RotationalCollisionTest_LShapeDrop_RotationFromAsymmetricCOM)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests

--- a/msd/msd-sim/test/Physics/Collision/RotationalEnergyTest.cpp
+++ b/msd/msd-sim/test/Physics/Collision/RotationalEnergyTest.cpp
@@ -66,7 +66,7 @@ double computeSystemEnergy(const WorldModel& world)
 // ============================================================================
 
 TEST_F(ReplayEnabledTest,
-       RotationalEnergyTest_F4_RotationEnergyTransfer_EnergyConserved)
+       RotationalEnergyTest_RotationEnergyTransfer_EnergyConserved)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests
@@ -211,7 +211,7 @@ TEST_F(ReplayEnabledTest,
 // ============================================================================
 
 TEST_F(ReplayEnabledTest,
-       RotationalEnergyTest_F4b_ZeroGravity_RotationalEnergyTransfer_Conserved)
+       RotationalEnergyTest_ZeroGravity_RotationalEnergyTransfer_Conserved)
 {
   // Ticket: 0039c_rotational_coupling_test_suite
   // Ticket: 0062c_replay_rotational_collision_tests

--- a/msd/msd-sim/test/Physics/Constraints/ConstraintPoolTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ConstraintPoolTest.cpp
@@ -62,21 +62,21 @@ FrictionConstraint* allocateTestFriction(ConstraintPool& pool,
 
 // ===== ConstraintPool Unit Tests =====
 
-TEST(ConstraintPoolTest, InitialState_CountsAreZero_0071g)
+TEST(ConstraintPoolTest, InitialState_CountsAreZero)
 {
   ConstraintPool pool;
   EXPECT_EQ(pool.contactCount(), 0u);
   EXPECT_EQ(pool.frictionCount(), 0u);
 }
 
-TEST(ConstraintPoolTest, AllocateContact_ReturnsNonNullPointer_0071g)
+TEST(ConstraintPoolTest, AllocateContact_ReturnsNonNullPointer)
 {
   ConstraintPool pool;
   ContactConstraint* cc = allocateTestContact(pool);
   ASSERT_NE(cc, nullptr);
 }
 
-TEST(ConstraintPoolTest, AllocateContact_IncreasesContactCount_0071g)
+TEST(ConstraintPoolTest, AllocateContact_IncreasesContactCount)
 {
   ConstraintPool pool;
   allocateTestContact(pool);
@@ -87,14 +87,14 @@ TEST(ConstraintPoolTest, AllocateContact_IncreasesContactCount_0071g)
   EXPECT_EQ(pool.contactCount(), 2u);
 }
 
-TEST(ConstraintPoolTest, AllocateFriction_ReturnNonNullPointer_0071g)
+TEST(ConstraintPoolTest, AllocateFriction_ReturnNonNullPointer)
 {
   ConstraintPool pool;
   FrictionConstraint* fc = allocateTestFriction(pool);
   ASSERT_NE(fc, nullptr);
 }
 
-TEST(ConstraintPoolTest, AllocateFriction_IncreasesFrictionCount_0071g)
+TEST(ConstraintPoolTest, AllocateFriction_IncreasesFrictionCount)
 {
   ConstraintPool pool;
   allocateTestFriction(pool);
@@ -105,7 +105,7 @@ TEST(ConstraintPoolTest, AllocateFriction_IncreasesFrictionCount_0071g)
   EXPECT_EQ(pool.frictionCount(), 2u);
 }
 
-TEST(ConstraintPoolTest, AllocateContact_ConstraintHasCorrectNormal_0071g)
+TEST(ConstraintPoolTest, AllocateContact_ConstraintHasCorrectNormal)
 {
   ConstraintPool pool;
   ContactConstraint* cc = allocateTestContact(pool);
@@ -115,7 +115,7 @@ TEST(ConstraintPoolTest, AllocateContact_ConstraintHasCorrectNormal_0071g)
   EXPECT_NEAR(cc->getContactNormal().z(), kNormal.z(), 1e-10);
 }
 
-TEST(ConstraintPoolTest, AllocateContact_ConstraintHasPenetrationDepth_0071g)
+TEST(ConstraintPoolTest, AllocateContact_ConstraintHasPenetrationDepth)
 {
   ConstraintPool pool;
   ContactConstraint* cc = allocateTestContact(pool);
@@ -123,7 +123,7 @@ TEST(ConstraintPoolTest, AllocateContact_ConstraintHasPenetrationDepth_0071g)
   EXPECT_NEAR(cc->getPenetrationDepth(), kPenetrationDepth, 1e-10);
 }
 
-TEST(ConstraintPoolTest, AllocateContact_ConstraintHasBodyIndices_0071g)
+TEST(ConstraintPoolTest, AllocateContact_ConstraintHasBodyIndices)
 {
   ConstraintPool pool;
   ContactConstraint* cc = allocateTestContact(pool, 3, 7);
@@ -132,7 +132,7 @@ TEST(ConstraintPoolTest, AllocateContact_ConstraintHasBodyIndices_0071g)
   EXPECT_EQ(cc->bodyBIndex(), 7u);
 }
 
-TEST(ConstraintPoolTest, Reset_CountsBecomeZero_0071g)
+TEST(ConstraintPoolTest, Reset_CountsBecomeZero)
 {
   ConstraintPool pool;
   allocateTestContact(pool);
@@ -147,7 +147,7 @@ TEST(ConstraintPoolTest, Reset_CountsBecomeZero_0071g)
   EXPECT_EQ(pool.frictionCount(), 0u);
 }
 
-TEST(ConstraintPoolTest, Reset_ThenReallocate_ProducesValidConstraints_0071g)
+TEST(ConstraintPoolTest, Reset_ThenReallocate_ProducesValidConstraints)
 {
   // This tests the steady-state behavior: reset clears counts, capacity is
   // retained, and the next allocation batch produces valid constraints.
@@ -177,7 +177,7 @@ TEST(ConstraintPoolTest, Reset_ThenReallocate_ProducesValidConstraints_0071g)
   EXPECT_NEAR(fc->getFrictionCoefficient(), kFrictionCoeff, 1e-10);
 }
 
-TEST(ConstraintPoolTest, PointerStability_WithReserve_PointersRemainValid_0071g)
+TEST(ConstraintPoolTest, PointerStability_WithReserve_PointersRemainValid)
 {
   // After reserveContacts(n) and reserveFriction(n), all emplace_back calls
   // within n elements must not invalidate previously returned pointers.
@@ -211,7 +211,7 @@ TEST(ConstraintPoolTest, PointerStability_WithReserve_PointersRemainValid_0071g)
   }
 }
 
-TEST(ConstraintPoolTest, MultipleResetCycles_NoHeapGrowthAfterHighWaterMark_0071g)
+TEST(ConstraintPoolTest, MultipleResetCycles_NoHeapGrowthAfterHighWaterMark)
 {
   // Simulate multiple frames: allocate, reset, allocate.
   // After the first allocation, capacity is retained; counts return to zero on reset.
@@ -232,7 +232,7 @@ TEST(ConstraintPoolTest, MultipleResetCycles_NoHeapGrowthAfterHighWaterMark_0071
   }
 }
 
-TEST(ConstraintPoolTest, AllocateManyContacts_CountsCorrect_0071g)
+TEST(ConstraintPoolTest, AllocateManyContacts_CountsCorrect)
 {
   ConstraintPool pool;
   pool.reserveContacts(200);
@@ -248,7 +248,7 @@ TEST(ConstraintPoolTest, AllocateManyContacts_CountsCorrect_0071g)
   EXPECT_EQ(pool.frictionCount(), 200u);
 }
 
-TEST(ConstraintPoolTest, ReserveContacts_DoesNotAllocateConstraints_0071g)
+TEST(ConstraintPoolTest, ReserveContacts_DoesNotAllocateConstraints)
 {
   // reserveContacts() changes capacity but not count
   ConstraintPool pool;
@@ -258,7 +258,7 @@ TEST(ConstraintPoolTest, ReserveContacts_DoesNotAllocateConstraints_0071g)
   EXPECT_EQ(pool.frictionCount(), 0u);
 }
 
-TEST(ConstraintPoolTest, ReserveFriction_DoesNotAllocateConstraints_0071g)
+TEST(ConstraintPoolTest, ReserveFriction_DoesNotAllocateConstraints)
 {
   ConstraintPool pool;
   pool.reserveFriction(50);

--- a/msd/msd-sim/test/Physics/Constraints/ConstraintSolverASMTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ConstraintSolverASMTest.cpp
@@ -53,7 +53,7 @@ Eigen::Matrix3d createIdentityInertia()
 // 1. ActiveSetResult Default Construction
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, ActiveSetResult_DefaultConstruction_Zeroed_0034)
+TEST(ConstraintSolverASMTest, ActiveSetResult_DefaultConstruction_Zeroed)
 {
   // Verify ActiveSetResult default constructor initializes all fields
   // correctly. active_set_size defaults to 0 (empty active set), not an
@@ -79,7 +79,7 @@ TEST(ConstraintSolverASMTest, ActiveSetResult_DefaultConstruction_Zeroed_0034)
 // ============================================================================
 
 TEST(ConstraintSolverASMTest,
-     SingleContact_ExactSolution_MatchesAnalytical_0034)
+     SingleContact_ExactSolution_MatchesAnalytical)
 {
   // For a single contact, lambda = b / A (scalar).
   // ASM should match this analytical result within 1e-12.
@@ -122,7 +122,7 @@ TEST(ConstraintSolverASMTest,
 // ============================================================================
 
 TEST(ConstraintSolverASMTest,
-     OrderIndependence_ShuffledContacts_IdenticalLambdas_0034)
+     OrderIndependence_ShuffledContacts_IdenticalLambdas)
 {
   // Two different orderings of the same contacts must produce identical
   // lambdas. ASM is deterministic and order-independent (unlike PGS).
@@ -211,7 +211,7 @@ TEST(ConstraintSolverASMTest,
 // 4. High Mass Ratio
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, HighMassRatio_1e6_Converges_0034)
+TEST(ConstraintSolverASMTest, HighMassRatio_1e6_Converges)
 {
   // ASM should converge for mass ratio 1e6:1 (LLT handles this easily).
   ConstraintSolver solver;
@@ -249,7 +249,7 @@ TEST(ConstraintSolverASMTest, HighMassRatio_1e6_Converges_0034)
 // 5. All Separating — Empty Active Set
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, AllSeparating_EmptyActiveSet_0034)
+TEST(ConstraintSolverASMTest, AllSeparating_EmptyActiveSet)
 {
   // All contacts separating: all lambdas should be zero.
   ConstraintSolver solver;
@@ -306,7 +306,7 @@ TEST(ConstraintSolverASMTest, AllSeparating_EmptyActiveSet_0034)
 // 6. All Compressive — Full Active Set
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, AllCompressive_FullActiveSet_0034)
+TEST(ConstraintSolverASMTest, AllCompressive_FullActiveSet)
 {
   // All contacts compressive: all lambdas should be positive.
   ConstraintSolver solver;
@@ -366,7 +366,7 @@ TEST(ConstraintSolverASMTest, AllCompressive_FullActiveSet_0034)
 // 7. Mixed Active/Inactive — Correct Partition
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, MixedActiveInactive_CorrectPartition_0034)
+TEST(ConstraintSolverASMTest, MixedActiveInactive_CorrectPartition)
 {
   // Ticket: 0040b — Updated for split impulse (no Baumgarte in velocity RHS).
   // One contact compressive (approaching bodies), one separating
@@ -435,7 +435,7 @@ TEST(ConstraintSolverASMTest, MixedActiveInactive_CorrectPartition_0034)
 // ============================================================================
 
 TEST(ConstraintSolverASMTest,
-     RedundantContacts_RegularizationPreventsFailure_0034)
+     RedundantContacts_RegularizationPreventsFailure)
 {
   // Two contacts at the exact same point with same normal.
   // Without regularization, A_W would be singular. With kRegularizationEpsilon,
@@ -481,7 +481,7 @@ TEST(ConstraintSolverASMTest,
 // 9. Safety Cap Reached — Reports Not Converged
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, SafetyCapReached_ReportsNotConverged_0034)
+TEST(ConstraintSolverASMTest, SafetyCapReached_ReportsNotConverged)
 {
   // Force the safety cap to be reached by setting max_safety_iterations = 1
   // on a scenario requiring multiple active set changes.
@@ -541,7 +541,7 @@ TEST(ConstraintSolverASMTest, SafetyCapReached_ReportsNotConverged_0034)
 // 10. KKT Conditions Verified Post-Solve
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, KKTConditions_VerifiedPostSolve_0034)
+TEST(ConstraintSolverASMTest, KKTConditions_VerifiedPostSolve)
 {
   // After a converged solve, explicitly verify all three KKT conditions:
   // 1. Primal feasibility: lambda >= 0
@@ -616,7 +616,7 @@ TEST(ConstraintSolverASMTest, KKTConditions_VerifiedPostSolve_0034)
 // 11. Iteration Count Within 2C Bound
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, IterationCount_WithinTwoCBound_0034)
+TEST(ConstraintSolverASMTest, IterationCount_WithinTwoCBound)
 {
   // For non-degenerate systems, ASM should converge within 2*C iterations.
   // Ticket: 0040b — stateA approaching stateB so contacts produce positive
@@ -692,7 +692,7 @@ TEST(ConstraintSolverASMTest, IterationCount_WithinTwoCBound_0034)
 // 12. Active Set Size Reported Correctly
 // ============================================================================
 
-TEST(ConstraintSolverASMTest, ActiveSetSize_ReportedCorrectly_0034)
+TEST(ConstraintSolverASMTest, ActiveSetSize_ReportedCorrectly)
 {
   // Verify that the number of non-zero lambdas matches expectations.
   // For all-compressive contacts, all lambdas should be positive.

--- a/msd/msd-sim/test/Physics/Constraints/ConstraintSolverContactTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ConstraintSolverContactTest.cpp
@@ -49,7 +49,7 @@ Eigen::Matrix3d createIdentityInertia()
 // 1. Basic PGS Convergence Tests
 // ============================================================================
 
-TEST(ConstraintSolverContactTest, EmptyContactSet_ReturnsConverged_0033)
+TEST(ConstraintSolverContactTest, EmptyContactSet_ReturnsConverged)
 {
   // Test: Zero contacts returns converged with empty forces
   ConstraintSolver solver;
@@ -67,7 +67,7 @@ TEST(ConstraintSolverContactTest, EmptyContactSet_ReturnsConverged_0033)
   EXPECT_EQ(0, result.iterations);
 }
 
-TEST(ConstraintSolverContactTest, SingleContact_Converges_0033)
+TEST(ConstraintSolverContactTest, SingleContact_Converges)
 {
   // Test: One penetrating contact produces converged result
   ConstraintSolver solver;
@@ -105,7 +105,7 @@ TEST(ConstraintSolverContactTest, SingleContact_Converges_0033)
   EXPECT_NEAR(0., result.bodyForces[1].angularTorque.norm(), 1e-9);
 }
 
-TEST(ConstraintSolverContactTest, MultipleContacts_Converges_0033)
+TEST(ConstraintSolverContactTest, MultipleContacts_Converges)
 {
   // Test: 2-4 simultaneous contacts converge
   ConstraintSolver solver;
@@ -183,7 +183,7 @@ TEST(ConstraintSolverContactTest, MultipleContacts_Converges_0033)
   EXPECT_NEAR(0., result.bodyForces[1].angularTorque.norm(), 1e-9);
 }
 
-TEST(ConstraintSolverContactTest, MaxIterationsReached_ReportsNotConverged_0033)
+TEST(ConstraintSolverContactTest, MaxIterationsReached_ReportsNotConverged)
 {
   // Test: Set max_safety_iterations=1 on a scenario requiring multiple active
   // set changes. With ASM, a mixed compressive/separating contact configuration
@@ -252,7 +252,7 @@ TEST(ConstraintSolverContactTest, MaxIterationsReached_ReportsNotConverged_0033)
 // 2. Lambda Non-Negativity (Unilateral Enforcement) Tests
 // ============================================================================
 
-TEST(ConstraintSolverContactTest, SeparatingBodies_LambdaZero_0033)
+TEST(ConstraintSolverContactTest, SeparatingBodies_LambdaZero)
 {
   // Test: Bodies moving apart produce lambda=0 (no adhesion)
   ConstraintSolver solver;
@@ -295,7 +295,7 @@ TEST(ConstraintSolverContactTest, SeparatingBodies_LambdaZero_0033)
   EXPECT_NEAR(0.0, result.lambdas(0), 1e-6);  // Lambda clamped to zero
 }
 
-TEST(ConstraintSolverContactTest, ApproachingBodies_LambdaPositive_0033)
+TEST(ConstraintSolverContactTest, ApproachingBodies_LambdaPositive)
 {
   // Test: Bodies approaching produce lambda>0 (repulsive force)
   ConstraintSolver solver;
@@ -340,7 +340,7 @@ TEST(ConstraintSolverContactTest, ApproachingBodies_LambdaPositive_0033)
   EXPECT_NEAR(0., result.bodyForces[1].angularTorque.norm(), 1e-9);
 }
 
-TEST(ConstraintSolverContactTest, RestingContact_LambdaNonNegative_0033)
+TEST(ConstraintSolverContactTest, RestingContact_LambdaNonNegative)
 {
   // Test: Bodies at rest on surface produce lambda>=0
   ConstraintSolver solver;
@@ -381,7 +381,7 @@ TEST(ConstraintSolverContactTest, RestingContact_LambdaNonNegative_0033)
 // 3. Per-Body Force Correctness Tests
 // ============================================================================
 
-TEST(ConstraintSolverContactTest, EqualMass_SymmetricForces_0033)
+TEST(ConstraintSolverContactTest, EqualMass_SymmetricForces)
 {
   // Test: Two equal-mass bodies receive equal and opposite forces
   ConstraintSolver solver;
@@ -423,7 +423,7 @@ TEST(ConstraintSolverContactTest, EqualMass_SymmetricForces_0033)
               1e-6);
 }
 
-TEST(ConstraintSolverContactTest, StaticBody_ZeroForceOnStatic_0033)
+TEST(ConstraintSolverContactTest, StaticBody_ZeroForceOnStatic)
 {
   // Test: Body with inverseMass=0 receives zero velocity change
   // Ticket: 0040b — stateA approaching stateB so contact produces positive
@@ -462,7 +462,7 @@ TEST(ConstraintSolverContactTest, StaticBody_ZeroForceOnStatic_0033)
   EXPECT_GT(result.bodyForces[1].linearForce.norm(), 0.0);
 }
 
-TEST(ConstraintSolverContactTest, ForceDirection_AlongContactNormal_0033)
+TEST(ConstraintSolverContactTest, ForceDirection_AlongContactNormal)
 {
   // Test: Constraint force is along the contact normal direction
   // Ticket: 0040b — stateA approaching stateB so contact produces positive
@@ -505,7 +505,7 @@ TEST(ConstraintSolverContactTest, ForceDirection_AlongContactNormal_0033)
   EXPECT_GT(fz, 1e-6);  // Significant Z component
 }
 
-TEST(ConstraintSolverContactTest, AngularForces_LeverArmProducesTorque_0033)
+TEST(ConstraintSolverContactTest, AngularForces_LeverArmProducesTorque)
 {
   // Test: Off-center contact produces angular constraint torque
   // Ticket: 0040b — stateA approaching stateB so contact produces positive
@@ -551,7 +551,7 @@ TEST(ConstraintSolverContactTest, AngularForces_LeverArmProducesTorque_0033)
 // ============================================================================
 
 TEST(ConstraintSolverContactTest,
-     HeadOnCollision_EqualMass_VelocityExchange_0033)
+     HeadOnCollision_EqualMass_VelocityExchange)
 {
   // Test: Two equal-mass bodies approaching head-on exchange velocities (e=1)
   ConstraintSolver solver;
@@ -590,7 +590,7 @@ TEST(ConstraintSolverContactTest,
 // Slop correction was removed from velocity-level RHS as it injected energy.
 // Penetration correction now handled exclusively by PositionCorrector.
 
-TEST(ConstraintSolverContactTest, Restitution_ZeroBounce_0033)
+TEST(ConstraintSolverContactTest, Restitution_ZeroBounce)
 {
   // Test: e=0 contact produces zero rebound (bodies stick)
   ConstraintSolver solver;
@@ -623,7 +623,7 @@ TEST(ConstraintSolverContactTest, Restitution_ZeroBounce_0033)
   EXPECT_GT(result.lambdas(0), 0.0);  // Contact force applied
 }
 
-TEST(ConstraintSolverContactTest, Restitution_FullBounce_0033)
+TEST(ConstraintSolverContactTest, Restitution_FullBounce)
 {
   // Test: e=1 contact produces full velocity reversal
   ConstraintSolver solver;
@@ -657,7 +657,7 @@ TEST(ConstraintSolverContactTest, Restitution_FullBounce_0033)
 }
 
 TEST(ConstraintSolverContactTest,
-     RestVelocityThreshold_DisablesRestitution_0033)
+     RestVelocityThreshold_DisablesRestitution)
 {
   // Test: Slow contact (below 0.5 m/s) disables restitution to prevent jitter
   ConstraintSolver solver;
@@ -697,7 +697,7 @@ TEST(ConstraintSolverContactTest,
 // 5. Edge Cases Tests
 // ============================================================================
 
-TEST(ConstraintSolverContactTest, BothBodiesStatic_AllLambdasZero_0033)
+TEST(ConstraintSolverContactTest, BothBodiesStatic_AllLambdasZero)
 {
   // Test: Two infinite-mass bodies: degenerate but should not crash
   ConstraintSolver solver;
@@ -733,7 +733,7 @@ TEST(ConstraintSolverContactTest, BothBodiesStatic_AllLambdasZero_0033)
   // inverseMass = 0
 }
 
-TEST(ConstraintSolverContactTest, ParallelContacts_SameNormal_0033)
+TEST(ConstraintSolverContactTest, ParallelContacts_SameNormal)
 {
   // Test: Multiple contacts with same normal converge correctly
   // Ticket: 0040b — stateA approaching stateB so contacts produce positive
@@ -787,7 +787,7 @@ TEST(ConstraintSolverContactTest, ParallelContacts_SameNormal_0033)
   EXPECT_GT(result.lambdas(1), 0.0);
 }
 
-TEST(ConstraintSolverContactTest, OrthogonalContacts_IndependentResolution_0033)
+TEST(ConstraintSolverContactTest, OrthogonalContacts_IndependentResolution)
 {
   // Test: Contacts on perpendicular faces resolve independently
   ConstraintSolver solver;
@@ -835,7 +835,7 @@ TEST(ConstraintSolverContactTest, OrthogonalContacts_IndependentResolution_0033)
   EXPECT_EQ(2, result.lambdas.size());
 }
 
-TEST(ConstraintSolverContactTest, HighMassRatio_Converges_0033)
+TEST(ConstraintSolverContactTest, HighMassRatio_Converges)
 {
   // Test: Mass ratio of 1000:1 still converges
   // Ticket: 0040b — stateA approaching stateB so contact produces positive
@@ -869,7 +869,7 @@ TEST(ConstraintSolverContactTest, HighMassRatio_Converges_0033)
   EXPECT_GT(result.lambdas(0), 0.0);
 }
 
-TEST(ConstraintSolverContactTest, ZeroPenetration_NoBias_0033)
+TEST(ConstraintSolverContactTest, ZeroPenetration_NoBias)
 {
   // Test: Contact at surface (penetration=0) produces no Baumgarte bias
   ConstraintSolver solver;
@@ -913,7 +913,7 @@ TEST(ConstraintSolverContactTest, ZeroPenetration_NoBias_0033)
 // 6. Solver Configuration Tests
 // ============================================================================
 
-TEST(ConstraintSolverContactTest, SetMaxIterations_Respected_0033)
+TEST(ConstraintSolverContactTest, SetMaxIterations_Respected)
 {
   // Test: setMaxIterations() limits PGS iteration count
   ConstraintSolver solver;
@@ -944,7 +944,7 @@ TEST(ConstraintSolverContactTest, SetMaxIterations_Respected_0033)
   EXPECT_LE(result.iterations, 5);  // Should not exceed max iterations
 }
 
-TEST(ConstraintSolverContactTest, SetConvergenceTolerance_EarlyExit_0033)
+TEST(ConstraintSolverContactTest, SetConvergenceTolerance_EarlyExit)
 {
   // Test: Tight tolerance requires more iterations; loose tolerance exits early
   ConstraintSolver solverTight;
@@ -984,7 +984,7 @@ TEST(ConstraintSolverContactTest, SetConvergenceTolerance_EarlyExit_0033)
   EXPECT_GE(resultTight.iterations, resultLoose.iterations);
 }
 
-TEST(ConstraintSolverContactTest, DefaultConfiguration_ReasonableDefaults_0033)
+TEST(ConstraintSolverContactTest, DefaultConfiguration_ReasonableDefaults)
 {
   // Test: Default max_iterations=10, tolerance=1e-4
   ConstraintSolver solver;

--- a/msd/msd-sim/test/Physics/Constraints/ContactConstraintFactoryTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ContactConstraintFactoryTest.cpp
@@ -73,7 +73,7 @@ InertialState createRotatingState(const Coordinate& position,
 // ContactConstraintFactory Tests
 // ============================================================================
 
-TEST(ContactConstraintFactoryTest, CreateFromCollision_SingleContact_0032a)
+TEST(ContactConstraintFactoryTest, CreateFromCollision_SingleContact)
 {
   // Test: Creates exactly 1 constraint for single contact point
   CollisionResult result;
@@ -96,7 +96,7 @@ TEST(ContactConstraintFactoryTest, CreateFromCollision_SingleContact_0032a)
 }
 
 TEST(ContactConstraintFactoryTest,
-     CreateFromCollision_ManifoldWith4Contacts_0032a)
+     CreateFromCollision_ManifoldWith4Contacts)
 {
   // Test: Creates 4 constraints for 4-point contact manifold
   CollisionResult result;
@@ -129,7 +129,7 @@ TEST(ContactConstraintFactoryTest,
   }
 }
 
-TEST(ContactConstraintFactoryTest, CombineRestitution_GeometricMean_0032a)
+TEST(ContactConstraintFactoryTest, CombineRestitution_GeometricMean)
 {
   // Test: combineRestitution returns sqrt(eA * eB)
   double eA = 0.8;
@@ -141,7 +141,7 @@ TEST(ContactConstraintFactoryTest, CombineRestitution_GeometricMean_0032a)
   EXPECT_NEAR(expected, combined, 1e-10);
 }
 
-TEST(ContactConstraintFactoryTest, CombineRestitution_ZeroValues_0032a)
+TEST(ContactConstraintFactoryTest, CombineRestitution_ZeroValues)
 {
   // Test: Returns zero when either coefficient is zero
   EXPECT_NEAR(
@@ -152,7 +152,7 @@ TEST(ContactConstraintFactoryTest, CombineRestitution_ZeroValues_0032a)
     0.0, contact_constraint_factory::combineRestitution(0.0, 0.0), 1e-10);
 }
 
-TEST(ContactConstraintFactoryTest, ComputeRelativeNormalVelocity_HeadOn_0032a)
+TEST(ContactConstraintFactoryTest, ComputeRelativeNormalVelocity_HeadOn)
 {
   // Test: Correctly computes relative normal velocity for head-on collision
   Coordinate normal{0, 0, 1};
@@ -175,7 +175,7 @@ TEST(ContactConstraintFactoryTest, ComputeRelativeNormalVelocity_HeadOn_0032a)
 }
 
 TEST(ContactConstraintFactoryTest,
-     ComputeRelativeNormalVelocity_WithAngular_0032a)
+     ComputeRelativeNormalVelocity_WithAngular)
 {
   // Test: Includes angular velocity contribution (ω × r term)
   Coordinate normal{0, 0, 1};
@@ -201,7 +201,7 @@ TEST(ContactConstraintFactoryTest,
 }
 
 TEST(ContactConstraintFactoryTest,
-     RestVelocityThreshold_DisablesRestitution_0032a)
+     RestVelocityThreshold_DisablesRestitution)
 {
   // Test: Restitution disabled below rest velocity threshold (0.5 m/s)
   CollisionResult result;
@@ -228,7 +228,7 @@ TEST(ContactConstraintFactoryTest,
 }
 
 TEST(ContactConstraintFactoryTest,
-     CreateFromCollision_NoContacts_ReturnsEmpty_0032a)
+     CreateFromCollision_NoContacts_ReturnsEmpty)
 {
   // Test: Returns empty vector when contactCount == 0
   CollisionResult result;

--- a/msd/msd-sim/test/Physics/Constraints/ContactConstraintTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ContactConstraintTest.cpp
@@ -117,7 +117,7 @@ InertialState createDefaultState(const Coordinate& position = Coordinate{0.0,
 // ContactConstraint Tests
 // ============================================================================
 
-TEST(ContactConstraintTest, Dimension_ReturnsOne_0032a)
+TEST(ContactConstraintTest, Dimension_ReturnsOne)
 {
   // Test: ContactConstraint has dimension = 1 (single scalar constraint)
   Coordinate normal{0, 0, 1};
@@ -133,7 +133,7 @@ TEST(ContactConstraintTest, Dimension_ReturnsOne_0032a)
 }
 
 TEST(ContactConstraintTest,
-     EvaluateTwoBody_PenetratingBodies_ReturnsNegative_0032a)
+     EvaluateTwoBody_PenetratingBodies_ReturnsNegative)
 {
   // Test: C(q) < 0 for penetrating bodies (constraint violated)
   Coordinate normal{0, 0, 1};      // A → B
@@ -157,7 +157,7 @@ TEST(ContactConstraintTest,
 }
 
 TEST(ContactConstraintTest,
-     EvaluateTwoBody_SeparatedBodies_ReturnsPositive_0032a)
+     EvaluateTwoBody_SeparatedBodies_ReturnsPositive)
 {
   // Test: C(q) > 0 for separated bodies (constraint satisfied)
   Coordinate normal{0, 0, 1};
@@ -180,7 +180,7 @@ TEST(ContactConstraintTest,
   EXPECT_NEAR(0.2, C(0), 1e-10);
 }
 
-TEST(ContactConstraintTest, JacobianTwoBody_LinearComponents_0032a)
+TEST(ContactConstraintTest, JacobianTwoBody_LinearComponents)
 {
   // Test: Jacobian linear components are -n^T for A and +n^T for B
   Coordinate normal{0, 0, 1};
@@ -211,7 +211,7 @@ TEST(ContactConstraintTest, JacobianTwoBody_LinearComponents_0032a)
   EXPECT_NEAR(1.0, J(0, 8), 1e-10);  // n_z
 }
 
-TEST(ContactConstraintTest, JacobianTwoBody_AngularComponents_0032a)
+TEST(ContactConstraintTest, JacobianTwoBody_AngularComponents)
 {
   // Test: Jacobian angular components are -(r_A × n)^T and +(r_B × n)^T
   Coordinate normal{0, 0, 1};
@@ -243,7 +243,7 @@ TEST(ContactConstraintTest, JacobianTwoBody_AngularComponents_0032a)
   EXPECT_NEAR(0.0, J(0, 11), 1e-10);  // (r_B × n)_z
 }
 
-TEST(ContactConstraintTest, JacobianTwoBody_NumericalVerification_0032a)
+TEST(ContactConstraintTest, JacobianTwoBody_NumericalVerification)
 {
   // Test: Analytical Jacobian matches finite-difference numerical Jacobian
   Coordinate normal{
@@ -299,7 +299,7 @@ TEST(ContactConstraintTest, JacobianTwoBody_NumericalVerification_0032a)
   EXPECT_NEAR(rB_cross_n.z(), J_analytical(0, 11), 1e-10);
 }
 
-TEST(ContactConstraintTest, IsActiveTwoBody_PenetratingPair_ReturnsTrue_0032a)
+TEST(ContactConstraintTest, IsActiveTwoBody_PenetratingPair_ReturnsTrue)
 {
   // Test: isActive returns true for penetrating bodies
   Coordinate normal{0, 0, 1};
@@ -317,7 +317,7 @@ TEST(ContactConstraintTest, IsActiveTwoBody_PenetratingPair_ReturnsTrue_0032a)
   EXPECT_TRUE(constraint.isActive(stateA, stateB, 0.0));
 }
 
-TEST(ContactConstraintTest, IsActiveTwoBody_SeparatedPair_ReturnsFalse_0032a)
+TEST(ContactConstraintTest, IsActiveTwoBody_SeparatedPair_ReturnsFalse)
 {
   // Test: isActive returns false for clearly separated bodies
   Coordinate normal{0, 0, 1};
@@ -335,7 +335,7 @@ TEST(ContactConstraintTest, IsActiveTwoBody_SeparatedPair_ReturnsFalse_0032a)
   EXPECT_FALSE(constraint.isActive(stateA, stateB, 0.0));
 }
 
-TEST(ContactConstraintTest, BaumgarteParameters_DefaultERP_0032a)
+TEST(ContactConstraintTest, BaumgarteParameters_DefaultERP)
 {
   // Test: alpha() returns default ERP value (0.2)
   Coordinate normal{0, 0, 1};
@@ -351,7 +351,7 @@ TEST(ContactConstraintTest, BaumgarteParameters_DefaultERP_0032a)
   EXPECT_NEAR(0.0, constraint.beta(), 1e-10);
 }
 
-TEST(ContactConstraintTest, TypeName_ReturnsContactConstraint_0032a)
+TEST(ContactConstraintTest, TypeName_ReturnsContactConstraint)
 {
   // Test: typeName() returns "ContactConstraint"
   Coordinate normal{0, 0, 1};
@@ -367,7 +367,7 @@ TEST(ContactConstraintTest, TypeName_ReturnsContactConstraint_0032a)
 }
 
 TEST(ContactConstraintTest,
-     Constructor_InvalidNormal_ThrowsInvalidArgument_0032a)
+     Constructor_InvalidNormal_ThrowsInvalidArgument)
 {
   // Test: Constructor validates normal is unit length
   Coordinate normal{0, 0, 2.0};  // Not unit length
@@ -382,7 +382,7 @@ TEST(ContactConstraintTest,
 }
 
 TEST(ContactConstraintTest,
-     Constructor_NegativePenetration_ThrowsInvalidArgument_0032a)
+     Constructor_NegativePenetration_ThrowsInvalidArgument)
 {
   // Test: Constructor validates penetration depth >= 0
   Coordinate normal{0, 0, 1};
@@ -397,7 +397,7 @@ TEST(ContactConstraintTest,
 }
 
 TEST(ContactConstraintTest,
-     Constructor_InvalidRestitution_ThrowsInvalidArgument_0032a)
+     Constructor_InvalidRestitution_ThrowsInvalidArgument)
 {
   // Test: Constructor validates restitution in [0, 1]
   Coordinate normal{0, 0, 1};
@@ -415,7 +415,7 @@ TEST(ContactConstraintTest,
                std::invalid_argument);
 }
 
-TEST(ContactConstraintTest, Accessors_ReturnCorrectValues_0032a)
+TEST(ContactConstraintTest, Accessors_ReturnCorrectValues)
 {
   // Test: Accessor methods return construction values
   Coordinate normal{0, 0, 1};

--- a/msd/msd-sim/test/Physics/Constraints/ProjectedGaussSeidelTest.cpp
+++ b/msd/msd-sim/test/Physics/Constraints/ProjectedGaussSeidelTest.cpp
@@ -97,7 +97,7 @@ std::unique_ptr<FrictionConstraint> makeFrictionConstraint(
 // 1. Single contact normal — PGS converges to correct lambda
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, SingleContactNormal_ConvergesPositiveLambda_0073)
+TEST(ProjectedGaussSeidelTest, SingleContactNormal_ConvergesPositiveLambda)
 {
   // One body approaching a static surface. PGS should produce lambda > 0.
   // Normal = {0,0,1} (A→B). J*v = -n·vA + n·vB.
@@ -129,7 +129,7 @@ TEST(ProjectedGaussSeidelTest, SingleContactNormal_ConvergesPositiveLambda_0073)
 // ============================================================================
 
 TEST(ProjectedGaussSeidelTest,
-     SingleContactWithFriction_BallProjection_0073)
+     SingleContactWithFriction_BallProjection)
 {
   // Body sliding in X with contact normal in Z. Friction should oppose motion.
   // Verify: ||lambda_t|| <= mu * lambda_n (ball-projection)
@@ -174,7 +174,7 @@ TEST(ProjectedGaussSeidelTest,
 // 3. Warm-start reduces sweeps vs cold-start
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, WarmStart_ReducesSweepCount_0073)
+TEST(ProjectedGaussSeidelTest, WarmStart_ReducesSweepCount)
 {
   // With the correct warm-start lambda, PGS should converge in very few sweeps.
   // Cold-start from zero requires more sweeps.
@@ -215,7 +215,7 @@ TEST(ProjectedGaussSeidelTest, WarmStart_ReducesSweepCount_0073)
 // 4. Convergence tolerance — early exit before maxSweeps
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, ConvergenceTolerance_EarlyExit_0073)
+TEST(ProjectedGaussSeidelTest, ConvergenceTolerance_EarlyExit)
 {
   ProjectedGaussSeidel pgs;
   pgs.setMaxSweeps(1000);
@@ -245,7 +245,7 @@ TEST(ProjectedGaussSeidelTest, ConvergenceTolerance_EarlyExit_0073)
 // 5. Degenerate contact (A_ii ~ 0) — skip without crash
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, DegenerateContact_ZeroMass_NoNaNs_0073)
+TEST(ProjectedGaussSeidelTest, DegenerateContact_ZeroMass_NoNaNs)
 {
   // If both bodies have infinite mass (invMass = 0), A_ii = kRegularizationEpsilon
   // (tiny but nonzero). PGS should not crash and result should be finite.
@@ -277,7 +277,7 @@ TEST(ProjectedGaussSeidelTest, DegenerateContact_ZeroMass_NoNaNs_0073)
 // 6. Large friction island — converges, lambda matches ConstraintSolver
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, LargeFrictionIsland_MatchesConstraintSolver_0073)
+TEST(ProjectedGaussSeidelTest, LargeFrictionIsland_MatchesConstraintSolver)
 {
   // Build a 7-contact system with friction (7 CC + 7 FC = 21 rows > kASMThreshold=20).
   // ConstraintSolver::solve() should dispatch to PGS.
@@ -370,13 +370,13 @@ TEST(ProjectedGaussSeidelTest, LargeFrictionIsland_MatchesConstraintSolver_0073)
 // 7. ConstraintSolver threshold dispatch — n=20 uses ASM, n=21 uses PGS
 // ============================================================================
 
-TEST(ConstraintSolverThresholdTest, kASMThresholdValue_Is20_0073)
+TEST(ConstraintSolverThresholdTest, kASMThresholdValue_Is20)
 {
   // Design specifies kASMThreshold = 20 (constexpr, publicly accessible)
   EXPECT_EQ(20u, ConstraintSolver::kASMThreshold);
 }
 
-TEST(ConstraintSolverThresholdTest, ThresholdDispatchASM_20Rows_0073)
+TEST(ConstraintSolverThresholdTest, ThresholdDispatchASM_20Rows)
 {
   // 20 contacts (no friction) = 20 rows = exactly kASMThreshold.
   // Should use ASM path: iterations field is ASM iteration count (finite).
@@ -431,7 +431,7 @@ TEST(ConstraintSolverThresholdTest, ThresholdDispatchASM_20Rows_0073)
     << "ASM iterations should be bounded by 2*numContacts";
 }
 
-TEST(ConstraintSolverThresholdTest, ThresholdDispatchPGS_21Rows_0073)
+TEST(ConstraintSolverThresholdTest, ThresholdDispatchPGS_21Rows)
 {
   // 7 contacts + 7 frictions = 21 rows > kASMThreshold=20.
   // Should use PGS path: iterations field is sweep count.
@@ -501,7 +501,7 @@ TEST(ConstraintSolverThresholdTest, ThresholdDispatchPGS_21Rows_0073)
 // 8. Empty constraint list — both PGS and solver handle gracefully
 // ============================================================================
 
-TEST(ProjectedGaussSeidelTest, EmptyConstraints_ReturnsZeroLambdas_0073)
+TEST(ProjectedGaussSeidelTest, EmptyConstraints_ReturnsZeroLambdas)
 {
   ProjectedGaussSeidel pgs;
 

--- a/msd/msd-sim/test/Physics/InertialCalculationsTest.cpp
+++ b/msd/msd-sim/test/Physics/InertialCalculationsTest.cpp
@@ -75,7 +75,7 @@ std::vector<Coordinate> createRegularTetrahedronPoints(double edgeLength)
 
 }  // anonymous namespace
 
-TEST(InertialCalculationsTest, UnitCubeAnalytical_Ticket0026)
+TEST(InertialCalculationsTest, UnitCubeAnalytical)
 {
   // Arrange: Unit cube (side = 1, density = 1, centered at origin)
   auto points = createUnitCubePoints();
@@ -107,7 +107,7 @@ TEST(InertialCalculationsTest, UnitCubeAnalytical_Ticket0026)
   EXPECT_NEAR(I(2, 1), I(1, 2), 1e-10);
 }
 
-TEST(InertialCalculationsTest, RectangularBoxAnalytical_Ticket0026)
+TEST(InertialCalculationsTest, RectangularBoxAnalytical)
 {
   // Arrange: Rectangular box (2x3x4, density = 1, centered at origin)
   double a = 2.0, b = 3.0, c = 4.0;
@@ -145,7 +145,7 @@ TEST(InertialCalculationsTest, RectangularBoxAnalytical_Ticket0026)
   EXPECT_NEAR(I(2, 1), I(1, 2), 1e-10);
 }
 
-TEST(InertialCalculationsTest, RegularTetrahedronAnalytical_Ticket0026)
+TEST(InertialCalculationsTest, RegularTetrahedronAnalytical)
 {
   // Arrange: Regular tetrahedron (edge = 2.0, density = 1)
   double edgeLength = 2.0;
@@ -178,7 +178,7 @@ TEST(InertialCalculationsTest, RegularTetrahedronAnalytical_Ticket0026)
   EXPECT_NEAR(I(2, 1), I(1, 2), 1e-10);
 }
 
-TEST(InertialCalculationsTest, VolumeByproduct_Ticket0026)
+TEST(InertialCalculationsTest, VolumeByproduct)
 {
   // Arrange: Unit cube
   auto points = createUnitCubePoints();
@@ -196,7 +196,7 @@ TEST(InertialCalculationsTest, VolumeByproduct_Ticket0026)
     inertial_calculations::computeInertiaTensorAboutCentroid(hull, density));
 }
 
-TEST(InertialCalculationsTest, CentroidByproduct_Ticket0026)
+TEST(InertialCalculationsTest, CentroidByproduct)
 {
   // Arrange: Rectangular box centered at origin
   double a = 2.0, b = 3.0, c = 4.0;
@@ -215,7 +215,7 @@ TEST(InertialCalculationsTest, CentroidByproduct_Ticket0026)
     inertial_calculations::computeInertiaTensorAboutCentroid(hull, density));
 }
 
-TEST(InertialCalculationsTest, SymmetryProperty_Ticket0026)
+TEST(InertialCalculationsTest, SymmetryProperty)
 {
   // Arrange: Unit cube
   auto points = createUnitCubePoints();
@@ -232,7 +232,7 @@ TEST(InertialCalculationsTest, SymmetryProperty_Ticket0026)
   EXPECT_NEAR(I(1, 2), I(2, 1), 1e-10);
 }
 
-TEST(InertialCalculationsTest, PositiveDefinite_Ticket0026)
+TEST(InertialCalculationsTest, PositiveDefinite)
 {
   // Arrange: Unit cube
   auto points = createUnitCubePoints();
@@ -252,7 +252,7 @@ TEST(InertialCalculationsTest, PositiveDefinite_Ticket0026)
   EXPECT_GT(eigenvalues(2), 0.0);
 }
 
-TEST(InertialCalculationsTest, LargeCoordinateOffset_Ticket0026)
+TEST(InertialCalculationsTest, LargeCoordinateOffset)
 {
   // Arrange: Unit cube offset far from origin
   auto points = createUnitCubePoints();
@@ -281,7 +281,7 @@ TEST(InertialCalculationsTest, LargeCoordinateOffset_Ticket0026)
   EXPECT_NEAR(I(2, 2), expected_diagonal, 1e-8);
 }
 
-TEST(InertialCalculationsTest, ExtremeAspectRatio_Ticket0026)
+TEST(InertialCalculationsTest, ExtremeAspectRatio)
 {
   // Arrange: Very thin rectangular box (1:100:100 aspect ratio)
   double a = 0.01, b = 1.0, c = 1.0;
@@ -305,7 +305,7 @@ TEST(InertialCalculationsTest, ExtremeAspectRatio_Ticket0026)
   EXPECT_NEAR(I(2, 2), expected_zz, 1e-9);
 }
 
-TEST(InertialCalculationsTest, SingleTetrahedron_Ticket0026)
+TEST(InertialCalculationsTest, SingleTetrahedron)
 {
   // Arrange: Regular tetrahedron (minimum convex hull)
   double edgeLength = 1.0;
@@ -333,7 +333,7 @@ TEST(InertialCalculationsTest, SingleTetrahedron_Ticket0026)
   EXPECT_GT(eigenvalues(2), 0.0);
 }
 
-TEST(InertialCalculationsTest, Invaliddensity_Ticket0026)
+TEST(InertialCalculationsTest, Invaliddensity)
 {
   // Arrange: Unit cube
   auto points = createUnitCubePoints();
@@ -350,7 +350,7 @@ TEST(InertialCalculationsTest, Invaliddensity_Ticket0026)
     std::invalid_argument);
 }
 
-TEST(InertialCalculationsTest, InvalidHull_Ticket0026)
+TEST(InertialCalculationsTest, InvalidHull)
 {
   // Arrange: Empty hull
   ConvexHull hull;
@@ -362,7 +362,7 @@ TEST(InertialCalculationsTest, InvalidHull_Ticket0026)
     std::runtime_error);
 }
 
-TEST(InertialCalculationsTest, densityScaling_Ticket0026)
+TEST(InertialCalculationsTest, densityScaling)
 {
   // Arrange: Unit cube with two different densityes
   auto points = createUnitCubePoints();

--- a/msd/msd-sim/test/Physics/RigidBody/AssetEnvironmentTest.cpp
+++ b/msd/msd-sim/test/Physics/RigidBody/AssetEnvironmentTest.cpp
@@ -36,7 +36,7 @@ std::vector<Coordinate> createCubePoints(double size)
 // AssetEnvironment Tests
 // ============================================================================
 
-TEST(AssetEnvironmentTest, GetInverseMass_ReturnsZero_0032a)
+TEST(AssetEnvironmentTest, GetInverseMass_ReturnsZero)
 {
   // Test: getInverseMass() returns 0.0 for infinite mass
   auto points = createCubePoints(1.0);
@@ -48,7 +48,7 @@ TEST(AssetEnvironmentTest, GetInverseMass_ReturnsZero_0032a)
   EXPECT_DOUBLE_EQ(0.0, environment.getInverseMass());
 }
 
-TEST(AssetEnvironmentTest, GetInverseInertiaTensor_ReturnsZeroMatrix_0032a)
+TEST(AssetEnvironmentTest, GetInverseInertiaTensor_ReturnsZeroMatrix)
 {
   // Test: getInverseInertiaTensor() returns zero matrix for infinite inertia
   auto points = createCubePoints(1.0);
@@ -70,7 +70,7 @@ TEST(AssetEnvironmentTest, GetInverseInertiaTensor_ReturnsZeroMatrix_0032a)
   EXPECT_DOUBLE_EQ(0.0, inverseInertia(2, 2));
 }
 
-TEST(AssetEnvironmentTest, GetInertialState_ReturnsZeroVelocity_0032a)
+TEST(AssetEnvironmentTest, GetInertialState_ReturnsZeroVelocity)
 {
   // Test: getInertialState() returns static state with zero velocity
   auto points = createCubePoints(1.0);
@@ -98,7 +98,7 @@ TEST(AssetEnvironmentTest, GetInertialState_ReturnsZeroVelocity_0032a)
   EXPECT_DOUBLE_EQ(3.0, state.position.z());
 }
 
-TEST(AssetEnvironmentTest, GetCoefficientOfRestitution_DefaultValue_0032a)
+TEST(AssetEnvironmentTest, GetCoefficientOfRestitution_DefaultValue)
 {
   // Test: getCoefficientOfRestitution() returns default value (0.5)
   auto points = createCubePoints(1.0);
@@ -110,7 +110,7 @@ TEST(AssetEnvironmentTest, GetCoefficientOfRestitution_DefaultValue_0032a)
   EXPECT_DOUBLE_EQ(0.5, environment.getCoefficientOfRestitution());
 }
 
-TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_UpdatesValue_0032a)
+TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_UpdatesValue)
 {
   // Test: setCoefficientOfRestitution() updates the value
   auto points = createCubePoints(1.0);
@@ -123,7 +123,7 @@ TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_UpdatesValue_0032a)
   EXPECT_DOUBLE_EQ(0.8, environment.getCoefficientOfRestitution());
 }
 
-TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_ValidatesRange_0032a)
+TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_ValidatesRange)
 {
   // Test: setCoefficientOfRestitution() validates range [0, 1]
   auto points = createCubePoints(1.0);
@@ -144,7 +144,7 @@ TEST(AssetEnvironmentTest, SetCoefficientOfRestitution_ValidatesRange_0032a)
                std::invalid_argument);
 }
 
-TEST(AssetEnvironmentTest, Constructor_WithRestitution_SetsValue_0032a)
+TEST(AssetEnvironmentTest, Constructor_WithRestitution_SetsValue)
 {
   // Test: Constructor with restitution parameter sets the value
   auto points = createCubePoints(1.0);


### PR DESCRIPTION
## Summary
- Strip ticket number suffixes (`_0032a`, `_0033`, `_0034`, `_0071g`, `_0073`, `_Ticket0026`) from ~102 test names across 8 constraint/physics files
- Remove letter-number prefixes (`A1_`–`H10_`) from ~35 collision test names across 8 files
- Re-enable angular velocity assertion in `WorldModelContactIntegrationTest` now that friction is implemented via Block PGS (0075b)

## Test plan
- [x] Full test suite: 768 passed, 12 failed (all pre-existing), 2 disabled
- [x] Verified re-enabled `GlancingCollision_ProducesAngularVelocity` passes
- [x] Baseline comparison confirms same 12 failures before and after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)